### PR TITLE
Make apt idempotent (#2)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
 - name: update apt cache
   ansible.builtin.apt:
     update_cache: yes
+    cache_valid_time: "{{ update_package_cache_cache_valid_time  }}"
   when:
     - ansible_pkg_mgr == "apt"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,4 @@
+---
+# vars file for update_package_cache
+
+update_package_cache_cache_valid_time: 0


### PR DESCRIPTION
---
name: Make apt idempotent
about: Add `update_package_cache_cache_valid_time` variable to make the role idempotent when using apt
---

The `ansible.builtin.apt` by default uses a `cache_valid_time` set to `0` if `update_cache` is used. This PR adds a variable that defaults to `0` to keep the current default, but allow someone to change the `cache_valid_time`.

**Testing**

```
- name: test
  hosts: all
  become: true

  roles:
    - robertdebock.bootstrap
    - {
        role: robertdebock.update_package_cache,
        update_package_cache_cache_valid_time: 3600
      }
```


